### PR TITLE
Add TOML embark theme since Alacritty change from yml -> toml in 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,12 @@ import:
   - ~/.config/alacritty/themes/embark.yml
 ```
 
+### For Version: 0.13.1 or later use TOML instead of YML
+```
+import = [
+  "~/.config/alacritty/themes/embark.toml"
+]
+```
+
 > See [this](https://github.com/alacritty/alacritty-theme) repo for similar theme
 > handling.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import:
   - ~/.config/alacritty/themes/embark.yml
 ```
 
-### For Version: 0.13.1 or later use TOML instead of YML
+### For Version: 0.13.0 or later use TOML instead of YML
 ```
 import = [
   "~/.config/alacritty/themes/embark.toml"

--- a/embark.toml
+++ b/embark.toml
@@ -1,0 +1,27 @@
+[colors.bright]
+black = "#585273"
+blue = "#78a8ff"
+cyan = "#63f2f1"
+green = "#7fe9c3"
+magenta = "#7676ff"
+red = "#f02e6e"
+white = "#8a889d"
+yellow = "#f2b482"
+
+[colors.cursor]
+cursor = "#a1efd3"
+text = "#1e1c31"
+
+[colors.normal]
+black = "#1e1c31"
+blue = "#91ddff"
+cyan = "#abf8f7"
+green = "#a1efd3"
+magenta = "#d4bfff"
+red = "#f48fb1"
+white = "#cbe3e7"
+yellow = "#ffe6b3"
+
+[colors.primary]
+background = "#1e1c31"
+foreground = "#cbe3e7"


### PR DESCRIPTION
feat: add TOML format for alacritty version > 0.13.0

https://github.com/alacritty/alacritty/releases/tag/v0.13.0

<img width="616" alt="image" src="https://github.com/embark-theme/alacritty/assets/1768460/76d280f5-6286-49ef-b045-6b25bb6fc581">


